### PR TITLE
Add Spark max into Year 1 code base

### DIFF
--- a/src/main/cpp/hw/DragonSparkMax.cpp
+++ b/src/main/cpp/hw/DragonSparkMax.cpp
@@ -1,0 +1,249 @@
+#include "hw/DragonSparkMax.h"
+#include "hw/usages/MotorControllerUsage.h"
+#include "mechanisms/controllers/ControlData.h"
+
+#include "frc/smartdashboard/SmartDashboard.h"
+
+DragonSparkMax::DragonSparkMax( int id,  
+                                MotorControllerUsage::MOTOR_CONTROLLER_USAGE deviceType, 
+                                CANSparkMax::MotorType motorType, 
+                                double gearRatio) : IDragonMotorController(),
+                                m_id(id),
+                                m_spark(new CANSparkMax(id, motorType)),
+                                //m_controlMode(DRAGON_CONTROL_MODE::PERCENT_OUTPUT),
+                                m_outputRotationOffset(0.0),
+                                m_gearRatio(gearRatio),
+                                m_deviceType(deviceType)
+{
+    m_spark->GetPIDController().SetOutputRange(-1.0, 1.0, 0);
+    m_spark->GetPIDController().SetOutputRange(-1.0, 1.0, 1);
+    // m_spark->GetEncoder()
+    // m_spark->
+    // m_spark->SetParameter(CANSparkMaxLowLevel::ConfigParameter::kHallOffset, 0);
+    // m_spark->RestoreFactoryDefaults();
+    // m_spark->SetReverse(true);
+    m_spark->RestoreFactoryDefaults();
+    m_spark->SetOpenLoopRampRate(0.09); //0.2 0.25
+    m_spark->SetClosedLoopRampRate(0.02);
+    m_spark->GetEncoder().SetPosition(0);
+    SetRotationOffset(0);
+}
+
+double DragonSparkMax::GetRotations() const
+{
+    return GetRotationsWithGearNoOffset() - m_outputRotationOffset;
+}
+
+double DragonSparkMax::GetRPS() const
+{
+    return m_spark->GetEncoder().GetVelocity() / 60.0;
+}
+
+MotorControllerUsage::MOTOR_CONTROLLER_USAGE DragonSparkMax::GetType() const
+{
+    return m_deviceType;
+}
+
+int DragonSparkMax::GetID() const
+{
+    return m_id;
+}
+
+void DragonSparkMax::SetControlConstants(int slot, ControlData* controlInfo)
+{
+    if (controlInfo != nullptr)
+    {
+        switch (controlInfo->GetMode())
+        {
+            case ControlModes::PERCENT_OUTPUT:
+                m_spark->Set(0); // init to zero just to be safe
+                break;
+            
+            case ControlModes::POSITION_INCH:
+                m_spark->GetPIDController().SetReference(0, CANSparkMax::ControlType::kPosition, slot);
+                break;
+
+            case ControlModes::VELOCITY_RPS:
+                m_spark->GetPIDController().SetReference(0, CANSparkMax::ControlType::kVelocity, slot);
+                break;
+
+            default:
+                // danger11!!!!
+                m_spark->Set(0);
+                break;
+        }
+        m_spark->GetPIDController().SetP(controlInfo->GetP(), slot);
+        m_spark->GetPIDController().SetI(controlInfo->GetI(), slot);
+        m_spark->GetPIDController().SetD(controlInfo->GetD(), slot);
+        m_spark->GetPIDController().SetFF(controlInfo->GetF(), slot);
+    }
+}
+
+void DragonSparkMax::Set(double value)
+{
+    /**
+    switch (m_controlMode)
+    {
+        case DRAGON_CONTROL_MODE::PERCENT_OUTPUT:
+            m_spark->Set(value);
+            break;
+
+        case DRAGON_CONTROL_MODE::ROTATIONS:
+            // (rot * gear ratio) - m_outputRotationOffset
+            m_spark->GetPIDController().SetReference((value + m_outputRotationOffset) / m_gearRatio, rev::ControlType::kPosition, 0); // position is slot 0
+            break;
+
+        case DRAGON_CONTROL_MODE::RPS: //inches per second
+            m_spark->GetPIDController().SetReference((value / 60.0) / m_gearRatio, rev::ControlType::kVelocity, 1);
+            break;
+
+        default:
+            // bad news if we are in the default branch... stop the motor
+            m_spark->Set(0);
+            break;
+    }
+    **/
+   m_spark->Set(value);
+}
+
+void DragonSparkMax::SetRotationOffset(double rotations)
+{
+    m_outputRotationOffset = GetRotationsWithGearNoOffset() - rotations;
+}
+
+void DragonSparkMax::SetVoltageRamping(double ramping, double rampingClosedLoop)
+{
+    m_spark->SetOpenLoopRampRate(ramping);
+    m_spark->SetClosedLoopRampRate(ramping); //TODO: should closed and open be separate
+
+    if (rampingClosedLoop >= 0)
+    {
+        m_spark->SetClosedLoopRampRate(rampingClosedLoop);
+    }
+}
+
+void DragonSparkMax::EnableCurrentLimiting(bool enabled)
+{
+    // TODO:
+    // m_spark->SetSmart
+}
+
+void DragonSparkMax::EnableBrakeMode(bool enabled)
+{
+    m_spark->SetIdleMode(enabled ? rev::CANSparkMax::IdleMode::kBrake : rev::CANSparkMax::IdleMode::kCoast);
+}
+
+void DragonSparkMax::Invert(bool inverted)
+{
+    m_spark->SetInverted(inverted);
+    // m_spark->GetEncoder().SetPositionConversionFactor(inverted ? -1.0 : 1.0);
+}
+
+double DragonSparkMax::GetRotationsWithGearNoOffset() const
+{
+    return m_spark->GetEncoder().GetPosition() * m_gearRatio;
+}
+
+void DragonSparkMax::InvertEncoder(bool inverted)
+{
+    // m_spark->SetInverted()
+    // m_spark->GetEncoder().SetInverted(inverted);
+}
+
+CANSparkMax* DragonSparkMax::GetSparkMax()
+{
+    return m_spark;
+}
+
+void DragonSparkMax::SetSmartCurrentLimiting(int limit)
+{
+    m_spark->SetSmartCurrentLimit(limit);
+}
+
+// Dummy methods below
+std::shared_ptr<frc::MotorController> DragonSparkMax::GetSpeedController() const 
+{
+    return std::shared_ptr<frc::MotorController>();
+}
+
+double DragonSparkMax::GetCurrent() const
+{
+    return 0.0;
+}
+IDragonMotorController::MOTOR_TYPE DragonSparkMax::GetMotorType() const 
+{
+    return IDragonMotorController::MOTOR_TYPE::NEO500MOTOR;
+}
+
+void DragonSparkMax::SetSensorInverted(bool inverted) 
+{
+
+}
+void DragonSparkMax::SetDiameter
+(
+	double 	diameter
+)
+{
+}
+
+void DragonSparkMax::SetVoltage
+(
+	units::volt_t output
+)
+{
+	m_spark->SetVoltage(output);
+}
+
+bool DragonSparkMax::IsForwardLimitSwitchClosed() const
+{
+    return false;
+}
+
+bool DragonSparkMax::IsReverseLimitSwitchClosed() const
+{
+    return false;
+}
+
+void DragonSparkMax::EnableDisableLimitSwitches
+(
+	bool enable
+)
+{
+}
+
+void DragonSparkMax::EnableVoltageCompensation( double fullvoltage) 
+{
+}
+
+
+
+void DragonSparkMax::SetSelectedSensorPosition
+(
+	double  initialPosition
+) 
+{
+}
+
+        
+double DragonSparkMax::GetCountsPerInch() const 
+{
+	return 1.0;
+}
+double DragonSparkMax::GetCountsPerDegree() const 
+{
+	return 1.0;
+}
+
+double DragonSparkMax::GetCounts() const 
+{
+	return m_spark->GetAbsoluteEncoder(rev::SparkMaxAbsoluteEncoder::Type::kDutyCycle).GetPosition();
+}
+
+void DragonSparkMax::SetRemoteSensor(int canID, ctre::phoenix::motorcontrol::RemoteSensorSource deviceType) 
+{
+    
+}
+void DragonSparkMax::SetFramePeriodPriority(MOTOR_PRIORITY priority) 
+{
+
+}

--- a/src/main/cpp/hw/DragonSparkMax.h
+++ b/src/main/cpp/hw/DragonSparkMax.h
@@ -1,0 +1,86 @@
+/*
+* DragonSparkMax.h
+*
+* Date Created: Jan 15, 2019
+* Author: Jonah Shader
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "hw/interfaces/IDragonMotorController.h"
+#include "hw/usages/MotorControllerUsage.h"
+
+#include "rev/CANSparkMax.h"
+#include <ctre/phoenix/motorcontrol/RemoteSensorSource.h>
+
+// namespaces
+using namespace rev;
+
+class DragonSparkMax : public IDragonMotorController
+{
+public:
+    //note: two PIDs: 0 is position, 1 is velocity
+    // Constructors
+    DragonSparkMax() = delete;
+    DragonSparkMax( int id, 
+                    MotorControllerUsage::MOTOR_CONTROLLER_USAGE deviceType, 
+                    CANSparkMax::MotorType motorType, 
+                    double gearRatio);
+
+    virtual ~DragonSparkMax() = default;
+
+    // Getters
+    double GetRotations() const override;
+    double GetRPS() const override;
+    MotorControllerUsage::MOTOR_CONTROLLER_USAGE GetType() const override;
+    int GetID() const override;
+
+    // Setters
+    void SetControlConstants(int slot, ControlData* controlInfo) override;
+
+    void Set(double value) override;
+    void SetRotationOffset(double rotations) override;
+    void SetVoltageRamping(double ramping, double rampingClosedLoop = -1) override; // seconds 0 to full, set to 0 to disable
+    void EnableCurrentLimiting(bool enabled) override;
+    void EnableBrakeMode(bool enabled) override;
+    void Invert(bool inverted) override;
+
+    void InvertEncoder(bool inverted);
+    void SetSmartCurrentLimiting(int limit);
+    void SetSecondaryCurrentLimiting(int limit, int duration);
+    //CANError Follow(DragonSparkMax* leader, bool invert = false);
+
+    // dummy methods below
+    std::shared_ptr<frc::MotorController> GetSpeedController() const override;
+    double GetCurrent() const override;
+    IDragonMotorController::MOTOR_TYPE GetMotorType() const override;
+    void SetSensorInverted(bool inverted) override;
+    void SetDiameter( double diameter ) override;
+    void SetVoltage(units::volt_t output) override;
+    double GetCounts() const override;
+    void SetRemoteSensor(int canID, ctre::phoenix::motorcontrol::RemoteSensorSource deviceType) override;
+    void SetFramePeriodPriority(MOTOR_PRIORITY priority) override;
+    bool IsForwardLimitSwitchClosed() const override;
+    bool IsReverseLimitSwitchClosed() const override;
+    void EnableVoltageCompensation( double fullvoltage) override;
+    void SetSelectedSensorPosition(double  initialPosition) override;
+    double GetCountsPerInch() const override;
+    double GetCountsPerDegree() const override;
+    void EnableDisableLimitSwitches(bool enable) override;
+    double GetCountsPerRev() const override {return 1.0;}
+    double GetGearRatio() const override { return 1.0;}
+
+private:
+    double GetRotationsWithGearNoOffset() const;
+    int m_id;
+    CANSparkMax* m_spark;
+    //DRAGON_CONTROL_MODE m_controlMode;
+    double m_outputRotationOffset;
+    double m_gearRatio;
+    MotorControllerUsage::MOTOR_CONTROLLER_USAGE m_deviceType;
+
+    CANSparkMax* GetSparkMax();
+    
+};

--- a/src/main/cpp/hw/factories/DragonMotorControllerFactory.cpp
+++ b/src/main/cpp/hw/factories/DragonMotorControllerFactory.cpp
@@ -171,7 +171,6 @@ shared_ptr<IDragonMotorController> DragonMotorControllerFactory::CreateMotorCont
         smax->InvertEncoder( sensorInverted );
         smax->EnableCurrentLimiting( enableCurrentLimit );
         smax->SetSmartCurrentLimiting( continuousCurrentLimit );
-        printf("Setting SparkMax current limit to %d\n", continuousCurrentLimit);
 
         /**  TODO:  implement follower logic
         if ( followMotor > -1 )
@@ -236,4 +235,8 @@ void DragonMotorControllerFactory::CreateTypeMap()
 {
     m_typeMap["TALONSRX"] = DragonMotorControllerFactory::MOTOR_TYPE::TALONSRX;
     m_typeMap["FALCON"] = DragonMotorControllerFactory::MOTOR_TYPE::FALCON;
+    m_typeMap["BRUSHLESS_SPARK_MAX"] = DragonMotorControllerFactory::MOTOR_TYPE::BRUSHLESS_SPARK_MAX;
+    m_typeMap["BRUSHED_SPARK_MAX"] = DragonMotorControllerFactory::MOTOR_TYPE::BRUSHED_SPARK_MAX;
+
 }
+        	

--- a/src/main/cpp/hw/factories/DragonMotorControllerFactory.h
+++ b/src/main/cpp/hw/factories/DragonMotorControllerFactory.h
@@ -41,7 +41,9 @@ class DragonMotorControllerFactory
 	    enum MOTOR_TYPE
     	{
         	TALONSRX,				/// Controller is a Cross the Road Electronics (CTRE) Talon SRX on the CAN network
-			FALCON
+			FALCON,
+        	BRUSHLESS_SPARK_MAX,
+        	BRUSHED_SPARK_MAX
     	};
 
 

--- a/src/main/cpp/hw/xml/MotorXmlParser.cpp
+++ b/src/main/cpp/hw/xml/MotorXmlParser.cpp
@@ -23,7 +23,6 @@
 // FRC includes
 
 // Team 302 includes
-#include <hw/DragonTalonSRX.h>
 #include <hw/factories/DragonMotorControllerFactory.h>
 #include <hw/interfaces/IDragonMotorController.h>
 #include <utils/HardwareIDValidation.h>

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,0 +1,73 @@
+{
+    "fileName": "REVLib.json",
+    "name": "REVLib",
+    "version": "2023.1.3",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "https://maven.revrobotics.com/"
+    ],
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2023.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-java",
+            "version": "2023.1.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-cpp",
+            "version": "2023.1.3",
+            "libName": "REVLib",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "libName": "REVLibDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Grabbed Spark Max from Deep Space and put it into Year 1 Codebase.  There were several deprecated methods and updates to the interface that were implemented.  Most of these method changes no-op as they won't be used.